### PR TITLE
fix: add required permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -9,6 +9,11 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  issues: write
+  pull-requests: read
+  contents: read
+
 jobs:
   # Process new issues with automation
   process-new-issue:

--- a/.github/workflows/pr-issue-linking.yml
+++ b/.github/workflows/pr-issue-linking.yml
@@ -9,6 +9,11 @@ on:
   pull_request_target:
     types: [opened, closed]
 
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
 jobs:
   # Link PRs to issues automatically
   link-pr-to-issues:

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -10,6 +10,11 @@ on:
   workflow_dispatch:
     # Allow manual triggering
 
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
 jobs:
   stale:
     name: Mark Stale Issues


### PR DESCRIPTION
- Add 'issues: write' permission to issue-management.yml
- Add 'pull-requests: write' permission to pr-issue-linking.yml
- Add both permissions to stale-issues.yml
- Enables workflows to modify issues, labels, and assignments
- Resolves workflow execution failures due to insufficient permissions

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
